### PR TITLE
Support multiple simultaneous streams

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - RTSP_PROTOCOLS=tcp
   stream:
+    container_name: ${STREAM_ENDPOINT}
     image: baicontainers/rtsp-feed
     networks:
       - rtsp-server

--- a/environment.sh
+++ b/environment.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-export RTSP_PORT=8561
+export RTSP_PORT=554

--- a/run-feed.sh
+++ b/run-feed.sh
@@ -14,8 +14,12 @@ if [ -f ${file_path} -o -d ${file_path} ]; then
     volmount="${file_path}:${file_path}"
     echo "Passing volume mount arg ${volmount} into the container"
 fi
+stream_endpoint_additional=""
+if [ -d ${file_path} ]; then
+    stream_endpoint_additional="/filename without .mkv extension"
+fi
 echo "Starting rtsp stream on endpoint ${stream_endpoint} using file(s) at ${file_path} and exporting on RTSP port ${RTSP_PORT}"
-echo "Access with rtsp://$(ip route get 8.8.8.8 | tr -s ' ' | cut -d' ' -f7):${RTSP_PORT}/${stream_endpoint})"
+echo "Access with rtsp://$(ip route get 8.8.8.8 | tr -s ' ' | cut -d' ' -f7):${RTSP_PORT}/${stream_endpoint}${stream_endpoint_additional}"
 cat << EOF > .env
 RTSP_PORT=${RTSP_PORT}
 FILE_PATH=${file_path}

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,20 @@
 #!/bin/sh
 
+stream_file()
+{
+    filename=$1
+    stream_endpoint=$2
+    tmpfile=`mktemp`
+    find ${filename} -type f | sed 's/^/file /g' | sed '1s/^/ffconcat version 1.0\n/' > $tmpfile
+    endpoint="rtsp://$(ip route get 8.8.8.8 | tr -s ' ' | cut -d' ' -f7):${PORT}/${stream_endpoint}"
+    echo "Stream will be available at $endpoint"
+    echo "tmp file contents:"
+    cat ${tmpfile}
+    echo ffmpeg -re -fflags +genpts -stream_loop -1 -safe 0 -i $tmpfile -flush_packets 0 -c copy -f rtsp rtsp://rtsp_server:${PORT}/${stream_endpoint}
+    set -e
+    ffmpeg -re -fflags +genpts -stream_loop -1 -safe 0 -i $tmpfile -flush_packets 0 -c copy -f rtsp rtsp://rtsp_server:${PORT}/${stream_endpoint}
+}
+
 if [ -z "$FILE_PATH" ]; then 
   echo "'FILE_PATH' is not set. Please set FILE_PATH."; 
   exit 1
@@ -29,11 +44,15 @@ else
   echo "Handling standard file type..."
 fi
 
-tmpfile=`mktemp`
-find ${FILE_PATH} -type f | sed 's/^/file /g' | sed '1s/^/ffconcat version 1.0\n/' > $tmpfile
-endpoint="rtsp://$(ip route get 8.8.8.8 | tr -s ' ' | cut -d' ' -f7):${PORT}/${STREAM_ENDPOINT}"
-echo "Stream will be available at $endpoint"
-echo "tmp file contents:"
-cat ${tmpfile}
-echo ffmpeg -re -fflags +genpts -stream_loop -1 -safe 0 -i $tmpfile -flush_packets 0 -c copy -f rtsp rtsp://rtsp_server:${PORT}/${STREAM_ENDPOINT}
-ffmpeg -re -fflags +genpts -stream_loop -1 -safe 0 -i $tmpfile -flush_packets 0 -c copy -f rtsp rtsp://rtsp_server:${PORT}/${STREAM_ENDPOINT}
+if [ -d ${FILE_PATH} ]; then
+  echo "Reading content of directory at ${FILE_PATH}"
+  for file in ${FILE_PATH}/*; do
+    filename_no_extension=$(basename ${file} .mkv)
+    stream_file ${file} ${STREAM_ENDPOINT}/${filename_no_extension} &
+  done
+  echo "All streams running"
+  wait
+else
+  stream_file ${FILE_PATH} ${STREAM_ENDPOINT}
+fi
+


### PR DESCRIPTION
Instead of looping over a single endpoint for all files in a directory,
support looping a directory of files in individual stream endoints.

Move the default port to 554 to match live555