### PR TITLE
Update RTSP feed setup, README, and run-feed.sh (CV-1588)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,92 @@
-1. Build RTSP Feed Container
+# RTSP Feed Setup
 
-    ```bash
-    ./build.sh
-    ```
+### 1. Build RTSP Feed Container
 
-2. Run the rstp-feed container in the background
+```bash
+./build.sh
+```
 
-    ```bash
-    ./run-feed.sh BAI_STREAM_02 gs://path-to-google-storage-url 
-    ```
-    or
-    ```bash
-    ./run-feed.sh BAI_STREAM_02 /path/to/local/file
-    ```
-     or
-    ```bash
-    ./run-feed.sh BAI_STREAM_02 /path/to/local/dir
-    ```
+---
 
-3. Stop the container
-    Run
-    ```bash
-    docker-compose down
-    ```
-    From this directory
+### 2. Run the RTSP feed container in the background
 
-Copy the `docker-compose.yml` and `./run-feed.sh` script to another system to
-use the container without rebuilding.
+```bash
+./run-feed.sh <STREAM_ENDPOINT> <SOURCE_PATH>
+```
+
+**Examples:**
+
+* Using a Google Storage URL:
+
+```bash
+./run-feed.sh BAI_STREAM_02 gs://path-to-google-storage-url
+```
+
+* Using a local file:
+
+```bash
+./run-feed.sh BAI_STREAM_02 /path/to/local/file
+```
+
+* Using a local directory:
+
+```bash
+./run-feed.sh BAI_STREAM_02 /path/to/local/dir
+```
+
+* After running, the RTSP stream will be available at:
+
+```
+rtsp://<HOST_IP>:<RTSP_PORT>/<STREAM_ENDPOINT>
+```
+
+You can check your host IP in the script output or run:
+
+```bash
+ip route get 8.8.8.8 | tr -s ' ' | cut -d' ' -f7
+```
+
+> **Note:** The RTSP server currently supports both **TCP and UDP** connections.
+
+---
+
+### 3. Debug / Check if the stream is running
+
+Use `ffplay` to play the stream:
+
+```bash
+ffplay rtsp://<HOST_IP>:<RTSP_PORT>/<STREAM_ENDPOINT>
+```
+
+This will open a window and play the live RTSP stream.
+
+---
+
+### 4. Stop the containers
+
+```bash
+docker compose down
+```
+
+Run this from the same directory as `docker-compose.yml`.
+
+---
+
+### 5. Reuse on another system
+
+* Copy the `docker-compose.yml` and `run-feed.sh` script to another machine.
+* Set the `.env` variables or use the script arguments.
+* You can run the stream **without rebuilding the container**.
+
+---
+
+### 6. Notes
+
+* **RTSP Server Image:** Switched from `aler9/rtsp-simple-server` to `bluenviron/mediamtx`.
+* **Docker Command:** We now use `docker compose` instead of `docker-compose`.
+
+  * It is part of the modern Docker CLI, no separate installation required.
+  * Fully supported and maintained, avoiding deprecation warnings.
+  * Behaves the same as the old command but integrates better with Docker CLI commands.
+
+---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,15 @@
-version: "3.3"
 networks:
   rtsp-server:
 
 services:
   rtsp_server:
-    image: aler9/rtsp-simple-server
+    image: bluenviron/mediamtx
     networks:
       - rtsp-server
     ports:
       - ${RTSP_PORT}:8554
-      - 1935:1935 
-    environment:
-      - RTSP_PROTOCOLS=tcp
+      - 1935:1935
+
   stream:
     image: baicontainers/rtsp-feed
     networks:
@@ -19,7 +17,7 @@ services:
     volumes:
       - ${VOLUME_MOUNT}
     depends_on:
-      - rtsp_server 
+      - rtsp_server
     environment:
       - STREAM_ENDPOINT=${STREAM_ENDPOINT}
       - FILE_PATH=${FILE_PATH}

--- a/run-feed.sh
+++ b/run-feed.sh
@@ -22,4 +22,4 @@ FILE_PATH=${file_path}
 VOLUME_MOUNT=${volmount}
 STREAM_ENDPOINT=${stream_endpoint}
 EOF
-docker-compose up -d
+docker compose up -d


### PR DESCRIPTION
- Switched RTSP server image from `aler9/rtsp-simple-server` to `bluenviron/mediamtx`
- Updated README with:
  - Correct usage examples for local files, directories, and Google Storage URLs
  - Note that RTSP supports both TCP and UDP
  - Added ffplay command to debug/check the stream
  - Added Notes section explaining the docker compose switch
- Updated run-feed.sh to use `docker compose up -d` instead of `docker-compose up -d`
- Removed obsolete `version` field from docker-compose.yml references
- Clarified access URL instructions for the RTSP stream